### PR TITLE
Disable some import rules inside ts declaration files

### DIFF
--- a/packages/eslint-config-vtex-react/package.json
+++ b/packages/eslint-config-vtex-react/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "eslint-check": "eslint --print-config index.js | eslint-config-prettier-check",
     "dump-config": "eslint --print-config index.js > config-dump.json",
-    "version": "chan release $npm_package_version && git add CHANGELOG.md && git commit --amend --no-edit"
+    "version": "chan release $npm_package_version && git add CHANGELOG.md"
   },
   "repository": {
     "type": "git",

--- a/packages/eslint-config-vtex-react/package.json
+++ b/packages/eslint-config-vtex-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex-react",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "description": "VTEX's eslint config for React",
   "main": "index.js",
   "scripts": {
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/vtex/javascript#readme",
   "dependencies": {
-    "eslint-config-vtex": "^12.3.1",
+    "eslint-config-vtex": "^12.3.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.18.0",
     "eslint-plugin-react-hooks": "^2.3.0"

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Disable some import rules inside TypeScript declaration files.
 
 ## 12.3.1 - 2020-03-30
 ### Fixed

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [12.3.2] - 2020-04-01
 ### Changed
 - Disable some import rules inside TypeScript declaration files.
 
@@ -103,7 +105,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Lodash rules and prettier configs.
 
-[Unreleased]: https://github.com/vtex/javascript/compare/v12.2.1...HEAD
+[Unreleased]: https://github.com/vtex/typescript/compare/v12.3.2...HEAD
+[12.3.2]: https://github.com/vtex/typescript/compare/v12.3.1...v12.3.2
 [12.2.1]: https://github.com/vtex/javascript/compare/v12.2.0...v12.2.1
 [12.2.0]: https://github.com/vtex/javascript/compare/v12.1.0...v12.2.0
 [12.1.0]: https://github.com/vtex/javascript/compare/v12.0.5...v12.1.0

--- a/packages/eslint-config-vtex/package.json
+++ b/packages/eslint-config-vtex/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "eslint-check": "eslint --print-config index.js | eslint-config-prettier-check",
     "dump-config": "eslint --print-config index.js > config-dump.json",
-    "version": "chan release $npm_package_version && git add CHANGELOG.md && git commit --amend --no-edit"
+    "version": "chan release $npm_package_version && git add CHANGELOG.md"
   },
   "repository": {
     "type": "git",

--- a/packages/eslint-config-vtex/package.json
+++ b/packages/eslint-config-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex",
-  "version": "12.3.1",
+  "version": "12.3.2",
   "description": "VTEX's eslint config",
   "main": "index.js",
   "scripts": {
@@ -39,10 +39,10 @@
     "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-jest": "^23.7.0",
     "eslint-plugin-prettier": "^3.1.2",
-    "eslint-plugin-vtex": "^1.0.3"
+    "eslint-plugin-vtex": "^1.0.4"
   },
   "devDependencies": {
-    "@vtex/prettier-config": "^0.1.3",
+    "@vtex/prettier-config": "^0.1.4",
     "eslint": "^6.8.0",
     "prettier": "^1.18.2",
     "typescript": "^3.7.5"

--- a/packages/eslint-config-vtex/rules/typescript.js
+++ b/packages/eslint-config-vtex/rules/typescript.js
@@ -194,5 +194,13 @@ module.exports = {
         ],
       },
     },
+    {
+      files: ['*.d.ts'],
+      rules: {
+        'import/order': 'off',
+        'import/no-duplicates': 'off',
+        'import/export': 'off',
+      },
+    },
   ],
 }

--- a/packages/eslint-plugin-vtex/package.json
+++ b/packages/eslint-plugin-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-vtex",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "VTEX's ESLint plugin",
   "main": "index.js",
   "files": [

--- a/packages/eslint-plugin-vtex/package.json
+++ b/packages/eslint-plugin-vtex/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "version": "chan release $npm_package_version && git add CHANGELOG.md && git commit --amend --no-edit"
+    "version": "chan release $npm_package_version && git add CHANGELOG.md"
   },
   "jest": {
     "testPathIgnorePatterns": [

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/prettier-config",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "VTEX shared prettier config",
   "publishConfig": {
     "access": "public"

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -18,7 +18,7 @@
     "index.js"
   ],
   "scripts": {
-    "version": "chan release $npm_package_version && git add CHANGELOG.md && git commit --amend --no-edit"
+    "version": "chan release $npm_package_version && git add CHANGELOG.md"
   },
   "peerDependencies": {
     "prettier": "^1.19.1"

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -7,7 +7,7 @@
   "main": "tsconfig.json",
   "license": "MIT",
   "scripts": {
-    "version": "chan release $npm_package_version && git add CHANGELOG.md && git commit --amend --no-edit"
+    "version": "chan release $npm_package_version && git add CHANGELOG.md"
   },
   "peerDependencies": {
     "typescript": "^3.7.5"

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/tsconfig",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?
Some import rules inside of TypeScript declaration files causes some false-negatives.

#### What problem is this solving?
Given the following example

```typescript
// react/typings/vtex.checkout-resources.d.ts

declare module 'vtex.checkout-resources/QueryProfile' {
  import { DocumentNode } from 'graphql'
  const query: DocumentNode
  export default query
}

declare module 'vtex.checkout-resources/MutationUpdateOrderFormProfile' {
  import { DocumentNode } from 'graphql'
  const query: DocumentNode
  export default query
}
```

Currently, the lint rules will error on the imports, because they are not grouped together (and it will even autofix to an incorrect version!) and because we are importing `DocumentNode` twice, which is necessary because they are inside each individual declaration.

Also, in some cases the `export { default } from 'module'` also will be wrongly accusing an error, so that's why I disabled that rule too.

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.