### PR TITLE
Update prettier

### DIFF
--- a/packages/eslint-config-vtex-react/CHANGELOG.md
+++ b/packages/eslint-config-vtex-react/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 6.5.0 - 2020-06-01
 ### Added
--  `prettier` `v2.0` as acceptable dependency.
+- `prettier` `v2.0` as acceptable dependency.
 
 ## 6.3.1 - 2020-03-30
 ### Fixed

--- a/packages/eslint-config-vtex-react/CHANGELOG.md
+++ b/packages/eslint-config-vtex-react/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+-  `prettier` `v2.0` as acceptable dependency.
+
 ## 6.3.1 - 2020-03-30
 ### Fixed
 - Release cycle.

--- a/packages/eslint-config-vtex-react/package.json
+++ b/packages/eslint-config-vtex-react/package.json
@@ -41,12 +41,12 @@
   },
   "devDependencies": {
     "eslint": "^6.8.0",
-    "prettier": "^1.18.2",
+    "prettier": "^1.18.2 || ^2.0.4",
     "typescript": "^3.5.3"
   },
   "peerDependencies": {
     "eslint": "^6.8.0",
-    "prettier": "^1.19.1",
+    "prettier": "^1.18.2 || ^2.0.4",
     "typescript": "^3.7.5"
   }
 }

--- a/packages/eslint-config-vtex-react/package.json
+++ b/packages/eslint-config-vtex-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex-react",
-  "version": "6.4.0",
+  "version": "6.5.0",
   "description": "VTEX's eslint config for React",
   "main": "index.js",
   "scripts": {
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/vtex/javascript#readme",
   "dependencies": {
-    "eslint-config-vtex": "^12.4.0",
+    "eslint-config-vtex": "^12.5.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.18.0",
     "eslint-plugin-react-hooks": "^2.3.0"

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+-  `prettier` `v2.0` as acceptable dependency.
+
 ## [12.3.2] - 2020-04-01
 ### Changed
 - Disable some import rules inside TypeScript declaration files.

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 12.5.0 - 2020-06-01
 ### Added
--  `prettier` `v2.0` as acceptable dependency.
+- `prettier` `v2.0` as acceptable dependency.
 
 ## [12.3.2] - 2020-04-01
 ### Changed

--- a/packages/eslint-config-vtex/package.json
+++ b/packages/eslint-config-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex",
-  "version": "12.4.0",
+  "version": "12.5.0",
   "description": "VTEX's eslint config",
   "main": "index.js",
   "scripts": {
@@ -42,7 +42,7 @@
     "eslint-plugin-vtex": "^1.1.0"
   },
   "devDependencies": {
-    "@vtex/prettier-config": "^0.2.0",
+    "@vtex/prettier-config": "^0.3.0",
     "eslint": "^6.8.0",
     "prettier": "^1.18.2",
     "typescript": "^3.7.5"

--- a/packages/eslint-config-vtex/package.json
+++ b/packages/eslint-config-vtex/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "eslint": "^6.8.0",
-    "prettier": "^1.19.1",
+    "prettier": "^1.18.2 || ^2.0.4",
     "typescript": "^3.7.5"
   }
 }

--- a/packages/prettier-config/CHANGELOG.md
+++ b/packages/prettier-config/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+-  `prettier` `v2.0` as acceptable dependency.
+
 ## 0.2.0 - 2020-04-28
 ### Changed
 - Make prettier always add paranthesis to arrow fn args

--- a/packages/prettier-config/CHANGELOG.md
+++ b/packages/prettier-config/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 0.3.0 - 2020-06-01
 ### Added
--  `prettier` `v2.0` as acceptable dependency.
+- `prettier` `v2.0` as acceptable dependency.
 
 ## 0.2.0 - 2020-04-28
 ### Changed

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -21,6 +21,6 @@
     "version": "chan release $npm_package_version && git add CHANGELOG.md"
   },
   "peerDependencies": {
-    "prettier": "^1.19.1"
+    "prettier": "^1.18.2 || ^2.0.4"
   }
 }

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/prettier-config",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "VTEX shared prettier config",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Update prettier to latest version. It's not a breaking change for us because we explicitly define eac config property in our `@vtex/prettier-config`.
