### PR TITLE
Add env.es6:true to base eslint config

### DIFF
--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `env.es6: true` to base eslint config.
 
 ## [12.3.2] - 2020-04-01
 ### Changed

--- a/packages/eslint-config-vtex/index.js
+++ b/packages/eslint-config-vtex/index.js
@@ -17,6 +17,9 @@ module.exports = {
     ecmaVersion: 2019,
     sourceType: 'module',
   },
+  env: {
+    es6: true,
+  },
   globals: {
     __DEV__: true,
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add `es6: true` to our base config, so javascript only repos don't complain about things like `Promise is undefined`.
