### PR TITLE
Change maxStatements default value from 1 to 2

### DIFF
--- a/packages/eslint-plugin-vtex/CHANGELOG.md
+++ b/packages/eslint-plugin-vtex/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+
+- [`vtex/prefer-early-return`] Default `maxStatements` from `1` to `2`.
 
 ## [1.0.3] - 2020-01-24
 ### Fixed

--- a/packages/eslint-plugin-vtex/lib/configs/recommended.js
+++ b/packages/eslint-plugin-vtex/lib/configs/recommended.js
@@ -4,7 +4,7 @@ module.exports = {
     'vtex/prefer-early-return': [
       'warn',
       {
-        maxStatements: 1,
+        maxStatements: 2,
       },
     ],
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Change the `maxStatements` value from `1` to `2`, so the `vtex/prefer-early-return` is a bit more permissive and less annoying. One is too radical.