### PR TITLE
Make cypress global available to every file inside its directory

### DIFF
--- a/packages/eslint-config-vtex/rules/tests.js
+++ b/packages/eslint-config-vtex/rules/tests.js
@@ -4,7 +4,7 @@ module.exports = {
   overrides: [
     // ! CYPRESS
     {
-      files: ['**/cypress/**/*{.test,.spec,_spec}.{ts,tsx,js,jsx}'],
+      files: ['**/cypress/**/*.{ts,tsx,js,jsx}'],
       extends: ['plugin:cypress/recommended'],
       rules: {
         // Enforce assertions before taking a screenshot


### PR DESCRIPTION
Our current config only takes test files into account, but config files can use the `Cypress` global.

![image](https://user-images.githubusercontent.com/12702016/85168186-5744d000-b240-11ea-8301-ccaf18cbfdd9.png)

