### PR TITLE
Add padding lines between blocks

### DIFF
--- a/packages/eslint-config-vtex-react/package.json
+++ b/packages/eslint-config-vtex-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex-react",
-  "version": "6.5.1",
+  "version": "6.6.0",
   "description": "VTEX's eslint config for React",
   "main": "index.js",
   "scripts": {
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/vtex/javascript#readme",
   "dependencies": {
-    "eslint-config-vtex": "^12.5.1",
+    "eslint-config-vtex": "^12.6.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.18.0",
     "eslint-plugin-react-hooks": "^2.3.0"

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## 12.6.0 - 2020-06-24
 ### Added
 - Padding lines after multiline block-like statements such as `try-catch`, `if`, `while`, `for` etc.
 

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Padding lines after multiline block-like statements such as `try-catch`, `if`, `while`, `for` etc.
+
+### Changed
+- `padding-line-between-statements` is now a warning instead of an error.
 
 ## 12.5.1 - 2020-06-19
 ### Added

--- a/packages/eslint-config-vtex/package.json
+++ b/packages/eslint-config-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex",
-  "version": "12.5.1",
+  "version": "12.6.0",
   "description": "VTEX's eslint config",
   "main": "index.js",
   "scripts": {

--- a/packages/eslint-config-vtex/rules/style.js
+++ b/packages/eslint-config-vtex/rules/style.js
@@ -134,19 +134,41 @@ module.exports = {
     // Require or disallow padding lines between statements
     // https://eslint.org/docs/rules/padding-line-between-statements
     'padding-line-between-statements': [
-      'error',
+      'warn',
       // empty lines after declarations
-      // { blankLine: 'always', prev: ['const', 'let', 'var'], next: '*' },
-      // {
-      //   blankLine: 'any',
-      //   prev: ['const', 'let', 'var'],
-      //   next: ['const', 'let', 'var'],
-      // },
-      // empty lines before returns
-      // { blankLine: 'always', prev: '*', next: 'return' },
       {
         blankLine: 'always',
-        prev: ['function', 'class'],
+        prev: ['const', 'let', 'var'],
+        next: '*',
+      },
+      // allow to have none or one blank line between declarations
+      {
+        blankLine: 'any',
+        prev: ['const', 'let', 'var'],
+        next: ['const', 'let', 'var'],
+      },
+      // enforce blank lines after multiline declarations
+      {
+        blankLine: 'always',
+        prev: ['multiline-const', 'multiline-let', 'multiline-var'],
+        next: '*',
+      },
+      // empty lines before returns
+      {
+        blankLine: 'always',
+        prev: '*',
+        next: 'return',
+      },
+      // empty lines between switch cases and breaks
+      {
+        blankLine: 'always',
+        prev: ['case', 'break'],
+        next: ['case', 'break'],
+      },
+      // always require blankline after function, class declarations and multiline blocks (if, try-catch, etc)
+      {
+        blankLine: 'always',
+        prev: ['function', 'class', 'multiline-block-like'],
         next: '*',
       },
     ],

--- a/packages/eslint-config-vtex/rules/style.js
+++ b/packages/eslint-config-vtex/rules/style.js
@@ -163,7 +163,7 @@ module.exports = {
       {
         blankLine: 'always',
         prev: ['case', 'break'],
-        next: ['case', 'break'],
+        next: ['case', 'break', 'default'],
       },
       // always require blankline after function, class declarations and multiline blocks (if, try-catch, etc)
       {


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR aims to improve readability and understandability of our codebase by adding padding lines between multiline block-like statements and variable declarations. 

- MULTILINE `if`, `do-while`, `for`, `try-catch`, `switch` and similar statements will require a blank line below them.

- Variable declarations (`const`,`let`, `var`) will require a blank line below them if the next statement is not another variable declaration or a `return` statement.

- MULTILINE variable declarations will require a blank line below them.

- The `padding-line-between-statements` rule is now a warning instead of an error.

#### Examples

##### Before

![image](https://user-images.githubusercontent.com/12702016/85449446-27facf80-b56e-11ea-879b-4569490060fe.png)

##### After

![image](https://user-images.githubusercontent.com/12702016/85449480-2df0b080-b56e-11ea-9f2f-6a0c73d16021.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
