### PR TITLE
Allow console.info and block enums and add new `enforce-explicit-enum-values` rule

### DIFF
--- a/packages/eslint-config-vtex-react/package.json
+++ b/packages/eslint-config-vtex-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex-react",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "description": "VTEX's eslint config for React",
   "main": "index.js",
   "scripts": {
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/vtex/javascript#readme",
   "dependencies": {
-    "eslint-config-vtex": "^12.6.0",
+    "eslint-config-vtex": "^12.7.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.18.0",
     "eslint-plugin-react-hooks": "^2.3.0"

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Block Typescript `enum`s.
+- Allow `console.info`
 
 ## 12.6.0 - 2020-06-24
 ### Added

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
+### Changed
 - Block Typescript `enum`s.
 - Allow `console.info`
 

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## 12.7.0 - 2020-07-01
 ### Changed
 - Block Typescript `enum`s.
 - Allow `console.info`

--- a/packages/eslint-config-vtex/package.json
+++ b/packages/eslint-config-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex",
-  "version": "12.6.0",
+  "version": "12.7.0",
   "description": "VTEX's eslint config",
   "main": "index.js",
   "scripts": {
@@ -39,7 +39,7 @@
     "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-jest": "^23.7.0",
     "eslint-plugin-prettier": "^3.1.2",
-    "eslint-plugin-vtex": "^1.1.1"
+    "eslint-plugin-vtex": "^1.2.0"
   },
   "devDependencies": {
     "@vtex/prettier-config": "^0.3.1",

--- a/packages/eslint-config-vtex/rules/errors.js
+++ b/packages/eslint-config-vtex/rules/errors.js
@@ -15,7 +15,7 @@ module.exports = {
 
     // Disallow use of console
     // https://eslint.org/docs/rules/no-console
-    'no-console': ['error', { allow: ['warn', 'error'] }],
+    'no-console': ['error', { allow: ['warn', 'error', 'info'] }],
 
     // Disallow template literal placeholder syntax in regular strings
     // https://eslint.org/docs/rules/no-template-curly-in-string

--- a/packages/eslint-config-vtex/rules/style.js
+++ b/packages/eslint-config-vtex/rules/style.js
@@ -94,6 +94,12 @@ module.exports = {
         message:
           '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
       },
+      // ban all enums
+      {
+        selector: 'TSEnumDeclaration',
+        message:
+          "Literal types and enums in Typescript solve the same problem in many cases and the enum has some trade-offs that in most cases literal types don't. See https://github.com/vtex/typescript/issues/60 for more information.",
+      },
     ],
 
     // Disallow the use of Boolean literals in conditional expressions

--- a/packages/eslint-config-vtex/rules/style.js
+++ b/packages/eslint-config-vtex/rules/style.js
@@ -98,7 +98,7 @@ module.exports = {
       {
         selector: 'TSEnumDeclaration',
         message:
-          "Literal types and enums in Typescript solve the same problem in many cases and the enum has some trade-offs that in most cases literal types don't. See https://github.com/vtex/typescript/issues/60 for more information.",
+          "Literal types and enums, in many cases, solve the same problem while enum has some trade-offs that usually literal types don't. Consider using a literal type instead. See https://github.com/vtex/typescript/issues/60 for more information.",
       },
     ],
 

--- a/packages/eslint-config-vtex/rules/style.js
+++ b/packages/eslint-config-vtex/rules/style.js
@@ -96,7 +96,7 @@ module.exports = {
       },
       // ban all enums
       {
-        selector: 'TSEnumDeclaration',
+        selector: 'TSEnumDeclaration:not([const=true])',
         message:
           "Literal types and enums, in many cases, solve the same problem while enum has some trade-offs that usually literal types don't. Consider using a literal type instead. See https://github.com/vtex/typescript/issues/60 for more information.",
       },

--- a/packages/eslint-plugin-vtex/CHANGELOG.md
+++ b/packages/eslint-plugin-vtex/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## 1.2.0 - 2020-07-01
 ### Added
 - Add `vtex/enforce-explicit-enum-values` rule.
 

--- a/packages/eslint-plugin-vtex/CHANGELOG.md
+++ b/packages/eslint-plugin-vtex/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `vtex/enforce-explicit-enum-values` rule.
 
 ## 1.1.1 - 2020-06-19
 ### Changed

--- a/packages/eslint-plugin-vtex/README.md
+++ b/packages/eslint-plugin-vtex/README.md
@@ -27,3 +27,4 @@ After installing the module, just add it to your `plugins` array inside your `.e
 This plugin provides the following custom ESLint rules:
 
 - [`prefer-early-return`](/packages/eslint-plugin-vtex/docs/rules/prefer-early-return.md): Suggest early returning to prevent nesting and improve code readability.
+- [`enforce-explicit-enum-values`](/packages/eslint-plugin-vtex/docs/rules/enforce-explicit-enum-values.md): Enforce explicit enum values.

--- a/packages/eslint-plugin-vtex/docs/rules/enforce-explicit-enum-values.md
+++ b/packages/eslint-plugin-vtex/docs/rules/enforce-explicit-enum-values.md
@@ -1,0 +1,20 @@
+# Enforce explicit `enum` values (enforce-explicit-enum-values)
+
+WIP
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+```
+
+The following patterns are not warnings:
+
+```js
+```
+
+
+## When Not To Use It
+
+If you don't care about enums having implicit values you can safely disable this rule.

--- a/packages/eslint-plugin-vtex/docs/rules/enforce-explicit-enum-values.md
+++ b/packages/eslint-plugin-vtex/docs/rules/enforce-explicit-enum-values.md
@@ -1,19 +1,30 @@
 # Enforce explicit `enum` values (enforce-explicit-enum-values)
 
-WIP
+`enum`s are a practical way to organize semantically related constant values. However, by implicitly defining values, `enum`s can lead to unexpected bugs if it's modified without paying attention to the order of its items.
 
 ## Rule Details
 
-The following patterns are considered warnings:
+The following patterns are considered errors:
 
 ```js
+const enum Status {
+  Open,
+  Closed,
+}
 ```
+
+If someone adds a new `Status` value to the top, both `Open` and `Closed` would have its values altered.
 
 The following patterns are not warnings:
 
 ```js
+const enum Status {
+  Open = 0,
+  Closed = 1,
+}
 ```
 
+If someone adds a new `Status` value to the top, nothing would change as this rule makes the constants order unimportant.
 
 ## When Not To Use It
 

--- a/packages/eslint-plugin-vtex/docs/rules/enforce-explicit-enum-values.md
+++ b/packages/eslint-plugin-vtex/docs/rules/enforce-explicit-enum-values.md
@@ -6,7 +6,7 @@
 
 The following patterns are considered errors:
 
-```js
+```ts
 const enum Status {
   Open,
   Closed,
@@ -17,7 +17,7 @@ If someone adds a new `Status` value to the top, both `Open` and `Closed` would 
 
 The following patterns are not warnings:
 
-```js
+```ts
 const enum Status {
   Open = 0,
   Closed = 1,

--- a/packages/eslint-plugin-vtex/index.js
+++ b/packages/eslint-plugin-vtex/index.js
@@ -5,5 +5,6 @@ module.exports = {
   },
   rules: {
     'prefer-early-return': require('./lib/rules/prefer-early-return'),
+    'enforce-explicit-enum-values': require('./lib/rules/enforce-explicit-enum-values'),
   },
 }

--- a/packages/eslint-plugin-vtex/lib/configs/recommended.js
+++ b/packages/eslint-plugin-vtex/lib/configs/recommended.js
@@ -7,5 +7,6 @@ module.exports = {
         maxStatements: 2,
       },
     ],
+    'vtex/enforce-explicit-enum-values': 'error',
   },
 }

--- a/packages/eslint-plugin-vtex/lib/rules/enforce-explicit-enum-values.js
+++ b/packages/eslint-plugin-vtex/lib/rules/enforce-explicit-enum-values.js
@@ -1,0 +1,36 @@
+const { getDocUrl } = require('../includes/getDocUrl.js')
+
+const meta = {
+  docs: {
+    description: 'Enforce the usage of explicit values for enum entries.',
+    category: 'Best Practices',
+    recommended: 'error',
+    uri: getDocUrl('typescript/enforce-explict-enum-values'),
+  },
+}
+
+function create(context) {
+  function checkEnum(enumNode) {
+    const { members } = enumNode
+
+    for (const member of members) {
+      if (member.initializer != null) {
+        continue
+      }
+
+      context.report({
+        node: member,
+        message: `The value of the constant "${member.id.name}" should be explicitly defined.`,
+      })
+    }
+  }
+
+  return {
+    TSEnumDeclaration: checkEnum,
+  }
+}
+
+module.exports = {
+  meta,
+  create,
+}

--- a/packages/eslint-plugin-vtex/lib/rules/enforce-explicit-enum-values.js
+++ b/packages/eslint-plugin-vtex/lib/rules/enforce-explicit-enum-values.js
@@ -5,7 +5,7 @@ const meta = {
     description: 'Enforce the usage of explicit values for enum entries.',
     category: 'Best Practices',
     recommended: 'error',
-    uri: getDocUrl('typescript/enforce-explict-enum-values'),
+    uri: getDocUrl('enforce-explict-enum-values'),
   },
 }
 

--- a/packages/eslint-plugin-vtex/lib/rules/prefer-early-return.js
+++ b/packages/eslint-plugin-vtex/lib/rules/prefer-early-return.js
@@ -34,6 +34,7 @@ function create(context) {
     ...DEFAULT_OPTIONS,
     ...(context.options[0] || null),
   }
+
   const { maxStatements } = options
 
   function isOffendingConsequent(consequentNode) {
@@ -52,11 +53,13 @@ function create(context) {
 
   function checkFunctionBody(fnNode) {
     const bodyNode = fnNode.body
+
     if (bodyNode.type !== 'BlockStatement' || bodyNode.body.length === 0) {
       return
     }
 
     const lastNode = bodyNode.body[bodyNode.body.length - 1]
+
     if (!isOffendingIfStatement(lastNode)) {
       return
     }

--- a/packages/eslint-plugin-vtex/package.json
+++ b/packages/eslint-plugin-vtex/package.json
@@ -32,6 +32,8 @@
     "collectCoverage": false
   },
   "devDependencies": {
+    "@typescript-eslint/experimental-utils": "^3.5.0",
+    "@typescript-eslint/parser": "^3.5.0",
     "jest": "^24.8.0"
   },
   "peerDependencies": {

--- a/packages/eslint-plugin-vtex/package.json
+++ b/packages/eslint-plugin-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-vtex",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "VTEX's ESLint plugin",
   "main": "index.js",
   "files": [

--- a/packages/eslint-plugin-vtex/tests/lib/rules/enforce-explicit-enum-values.test.js
+++ b/packages/eslint-plugin-vtex/tests/lib/rules/enforce-explicit-enum-values.test.js
@@ -1,0 +1,39 @@
+const { ESLintUtils } = require('@typescript-eslint/experimental-utils')
+
+const rule = require('../../../lib/rules/enforce-explicit-enum-values.js')
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: '@typescript-eslint/parser',
+})
+
+ruleTester.run('prefer-early-return', rule, {
+  valid: [
+    {
+      code: `const enum Status {
+        Open = 0,
+        Close = 2,
+      }
+      `,
+    },
+  ],
+
+  invalid: [
+    {
+      code: `const enum Status {
+        Open,
+        Close,
+      }
+      `,
+      errors: [
+        {
+          message:
+            'The value of the constant "Open" should be explicitly defined.',
+        },
+        {
+          message:
+            'The value of the constant "Close" should be explicitly defined.',
+        },
+      ],
+    },
+  ],
+})

--- a/packages/eslint-plugin-vtex/tests/lib/rules/enforce-explicit-enum-values.test.js
+++ b/packages/eslint-plugin-vtex/tests/lib/rules/enforce-explicit-enum-values.test.js
@@ -6,7 +6,7 @@ const ruleTester = new ESLintUtils.RuleTester({
   parser: '@typescript-eslint/parser',
 })
 
-ruleTester.run('prefer-early-return', rule, {
+ruleTester.run('enforce-explicit-enum-values', rule, {
   valid: [
     {
       code: `const enum Status {


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Allow `console.info`
- Block non-const `enums` in favor of literal types.
- Add new `enforce-explicit-enum-values` rule to `eslint-plugin-vtex` so we can block enums with implicit values.

This could be considered a breaking change. I don't think changing existing enums to type literals will be a herculean job, but can be annoying for some folks.

Note:

We're only blocking simple `enum`s, `const enum`s  behave differently and, while they still have some of the problems described in #60, they do not generate runtime code and we'll be enforcing explicit values in the future via a custo rule in `eslint-plugin-vtex`.

#### What problem is this solving?

Mainly described in #60 

#### Screenshots or example usage

Generic enums:

![image](https://user-images.githubusercontent.com/12702016/86165476-b8469080-bae9-11ea-88a4-0b976c8496a5.png)

Const enums with implicit values: 
![image](https://user-images.githubusercontent.com/12702016/86183443-5f3a2500-bb08-11ea-8c18-8fb0d763aae5.png)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
