### PR TITLE
Change message from imports of ramda and lodash

### DIFF
--- a/packages/eslint-config-vtex-react/CHANGELOG.md
+++ b/packages/eslint-config-vtex-react/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Message from imports of `ramda` and `lodash`.
 
 ## 6.5.0 - 2020-06-01
 ### Added

--- a/packages/eslint-config-vtex-react/io.js
+++ b/packages/eslint-config-vtex-react/io.js
@@ -15,12 +15,12 @@ module.exports = {
               {
                 name: 'lodash',
                 message:
-                  'Lodash is a heavy library. Import only the methods you need or use native ones instead',
+                  'You might not need lodash, try using the default functions from the browser',
               },
               {
                 name: 'ramda',
                 message:
-                  'Ramda is a heavy library. Import only the methods you need or use native ones instead',
+                  'You might not need ramda, try using the default functions from the browser',
               },
             ],
             // Patterns don't support messages yet :(


### PR DESCRIPTION
#### What is the purpose of this pull request?

The imports of solo functions were making the bundle size bigger than smaller, so now we advice to not use either `ramda` or `lodash`


#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/8517023/87685672-0b5f4b00-c75a-11ea-821c-e7e1ca27571b.png)



#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
