### PR TITLE
Add useCustomClasses hook to io rules

### DIFF
--- a/packages/eslint-config-vtex-react/CHANGELOG.md
+++ b/packages/eslint-config-vtex-react/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## 6.8.4 - 2020-11-25
 ### Added
 - `useCustomClasses` hook to `react-hooks/exhaustive-deps` rule to io.
 

--- a/packages/eslint-config-vtex-react/CHANGELOG.md
+++ b/packages/eslint-config-vtex-react/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `useCustomClasses` hook to `react-hooks/exhaustive-deps` rule to io.
 
 ## 6.8.2 - 2020-11-19
 ### Added

--- a/packages/eslint-config-vtex-react/io.js
+++ b/packages/eslint-config-vtex-react/io.js
@@ -28,6 +28,16 @@ module.exports = {
             patterns: [],
           },
         ],
+
+        // Add useCustomClasses hook from vtex-apps/css-handles
+        // https://eslint.org/docs/rules/no-restricted-imports
+        'react-hooks/exhaustive-deps': [
+          'warn',
+          {
+            // regexp
+            additionalHooks: '(useCustomClasses)',
+          },
+        ],
       },
     },
   ],

--- a/packages/eslint-config-vtex-react/package.json
+++ b/packages/eslint-config-vtex-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex-react",
-  "version": "6.8.3",
+  "version": "6.8.4",
   "description": "VTEX's eslint config for React",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Use configuration of react-hooks plugin to match `useCustomClasses` hook from https://github.com/vtex-apps/css-handles/pull/22

Config docs: https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks#advanced-configuration

#### What problem is this solving?

Trigger warning if deps are missing.

#### How should this be manually tested?

n/a

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
