### PR TITLE
Add no-unneecessary-constraints and consitent-import-type rules, fix no-shadow

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "clean": "lerna clean && lerna run clean",
     "format:check": "prettier --list-different \"./**/*.{ts,js,json}\"",
     "format": "prettier --write \"**/*.{ts,js,json}\"",
-    "lint": "eslint . --ext .js,.ts,.jsx,.tsx",
-    "lint:fix": "eslint . --ext .js,.ts --fix",
+    "lint": "eslint --ext .js,.ts,.jsx,.tsx .",
     "test": "lerna run test --concurrency 1"
   },
   "prettier": "@vtex/prettier-config",
@@ -39,11 +38,11 @@
   },
   "devDependencies": {
     "@geut/chan": "^2.1.1",
-    "eslint": "^6.7.0",
-    "husky": "^4.2.0",
+    "eslint": "^7.14.0",
+    "husky": "^4.3.0",
     "lerna": "^3.18.4",
-    "lint-staged": "^10.0.2",
-    "prettier": "^1.19.1",
-    "typescript": "^3.7.5"
+    "lint-staged": "^10.5.2",
+    "prettier": "^2.2.0",
+    "typescript": "^3.8"
   }
 }

--- a/packages/eslint-config-vtex-react/demo/Component.tsx
+++ b/packages/eslint-config-vtex-react/demo/Component.tsx
@@ -1,4 +1,5 @@
-import React, { FC } from 'react'
+import type { FC } from 'react'
+import React from 'react'
 
 const AnotherComponent: FC = () => {
   return null

--- a/packages/eslint-config-vtex-react/demo/package.json
+++ b/packages/eslint-config-vtex-react/demo/package.json
@@ -3,8 +3,9 @@
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^6.8.0",
-    "prettier": "^1.19.1",
-    "typescript": "^3.7.5"
+    "@types/react": "^17.0.0"
+  },
+  "dependencies": {
+    "react": "^17.0.1"
   }
 }

--- a/packages/eslint-config-vtex-react/package.json
+++ b/packages/eslint-config-vtex-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex-react",
-  "version": "6.8.4",
+  "version": "6.8.5",
   "description": "VTEX's eslint config for React",
   "main": "index.js",
   "scripts": {
@@ -36,7 +36,7 @@
     "directory": "packages/eslint-config-vtex-react"
   },
   "dependencies": {
-    "eslint-config-vtex": "^12.8.11",
+    "eslint-config-vtex": "^12.8.12",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.6",
     "eslint-plugin-react-hooks": "^4.1.0"

--- a/packages/eslint-config-vtex-react/package.json
+++ b/packages/eslint-config-vtex-react/package.json
@@ -41,14 +41,9 @@
     "eslint-plugin-react": "^7.20.6",
     "eslint-plugin-react-hooks": "^4.1.0"
   },
-  "devDependencies": {
-    "eslint": "^6.8.0",
-    "prettier": "^1.18.2 || ^2.0.4",
-    "typescript": "^3.5.3"
-  },
   "peerDependencies": {
-    "eslint": "^6.0.0 || ^7.0.0",
+    "eslint": "^6 || ^7",
     "prettier": "^1.18.2 || ^2.0.4",
-    "typescript": "^3.7.5 || ^4.0.0"
+    "typescript": "^3.8 || ^4.0.0"
   }
 }

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## 12.8.12 - 2020-12-03
 ### Added
 - `@typescript-eslint/no-unnecessary-type-constraint` rule.
 - `@typescript-eslint/consistent-type-imports` rule.

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `@typescript-eslint/no-unnecessary-type-constraint` rule
+- `@typescript-eslint/no-unnecessary-type-constraint` rule.
+- `@typescript-eslint/consistent-type-imports` rule.
 
 ## 12.8.11 - 2020-11-23
 ### Fixed

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `@typescript-eslint/no-unnecessary-type-constraint` rule
 
 ## 12.8.11 - 2020-11-23
 ### Fixed

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `@typescript-eslint/no-unnecessary-type-constraint` rule.
 - `@typescript-eslint/consistent-type-imports` rule.
 
+### Fixed
+- `no-shadow` rule for TypeScript.
+
 ## 12.8.11 - 2020-11-23
 ### Fixed
 - Explicitly set a `jest` version for rule `jest/no-deprecated-functions` to work.

--- a/packages/eslint-config-vtex/demo/package.json
+++ b/packages/eslint-config-vtex/demo/package.json
@@ -5,6 +5,6 @@
   "devDependencies": {
     "eslint": "^6.8.0",
     "prettier": "^1.19.1",
-    "typescript": "^3.7.5"
+    "typescript": "^3.8"
   }
 }

--- a/packages/eslint-config-vtex/package.json
+++ b/packages/eslint-config-vtex/package.json
@@ -43,12 +43,6 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-vtex": "^2.0.7"
   },
-  "devDependencies": {
-    "@vtex/prettier-config": "^0.3.5",
-    "eslint": "^6.8.0",
-    "prettier": "^1.18.2",
-    "typescript": "^3.7.5"
-  },
   "peerDependencies": {
     "eslint": "^6 || ^7",
     "prettier": "^1 || ^2",

--- a/packages/eslint-config-vtex/package.json
+++ b/packages/eslint-config-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex",
-  "version": "12.8.11",
+  "version": "12.8.12",
   "description": "VTEX's eslint config",
   "main": "index.js",
   "scripts": {
@@ -41,7 +41,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.1.3",
     "eslint-plugin-prettier": "^3.1.4",
-    "eslint-plugin-vtex": "^2.0.7"
+    "eslint-plugin-vtex": "^2.0.8"
   },
   "peerDependencies": {
     "eslint": "^6 || ^7",

--- a/packages/eslint-config-vtex/rules/typescript.js
+++ b/packages/eslint-config-vtex/rules/typescript.js
@@ -255,6 +255,16 @@ module.exports = !hasTypescript
             // Disallows unnecessary constraints on generic types
             // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-type-constraint.md
             '@typescript-eslint/no-unnecessary-type-constraint': 'warn',
+
+            // Enforces consistent usage of type imports
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-imports.md
+            '@typescript-eslint/consistent-type-imports': [
+              'warn',
+              {
+                prefer: 'type-imports',
+                disallowTypeAnnotations: true,
+              },
+            ],
           },
         },
         {

--- a/packages/eslint-config-vtex/rules/typescript.js
+++ b/packages/eslint-config-vtex/rules/typescript.js
@@ -238,6 +238,7 @@ module.exports = !hasTypescript
             // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/ban-types.md
             //! Commented because we use the recommended version of this rule
             // '@typescript-eslint/ban-types': 'off',
+
             // Disallow // @ts comments
             // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/ban-ts-comment.md
             '@typescript-eslint/ban-ts-comment': [
@@ -250,6 +251,10 @@ module.exports = !hasTypescript
                 minimumDescriptionLength: 3,
               },
             ],
+
+            // Disallows unnecessary constraints on generic types
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-type-constraint.md
+            '@typescript-eslint/no-unnecessary-type-constraint': 'warn',
           },
         },
         {

--- a/packages/eslint-config-vtex/rules/typescript.js
+++ b/packages/eslint-config-vtex/rules/typescript.js
@@ -22,7 +22,6 @@ module.exports = !hasTypescript
               // look in the root
               'tsconfig{.eslint.json,.json}',
               // look in dirs like node/react
-              // TODO: can these negations be smarter?
               '*/tsconfig{.eslint.json,.json}',
               // look in dirs like packages/package/*
               '*/*/tsconfig{.eslint.json,.json}',
@@ -30,102 +29,18 @@ module.exports = !hasTypescript
             projectFolderIgnoreList: ['node_modules/**/*'],
           },
           rules: {
-            // Enforce explicit accessibility modifiers on class properties and methods
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md
-            '@typescript-eslint/explicit-member-accessibility': [
-              'error',
-              {
-                accessibility: 'explicit',
-                overrides: {
-                  accessors: 'explicit',
-                  constructors: 'no-public',
-                  methods: 'explicit',
-                  parameterProperties: 'explicit',
-                },
-              },
-            ],
-
-            // Enforce explicit function return type
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
-            '@typescript-eslint/explicit-function-return-type': 'off',
-
-            // Enforce a consistent way of typing arrays
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.mdv
-            '@typescript-eslint/array-type': [
-              'warn',
-              {
-                default: 'array-simple',
-                readonly: 'array-simple',
-              },
-            ],
-
-            // Enforce a consitent way to type objects
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-definitions.md
-            '@typescript-eslint/consistent-type-definitions': 'off',
-
-            // Disallow non null assertions (!), comes from the recommended config
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-non-null-assertion.md
-            '@typescript-eslint/no-non-null-assertion': 'warn',
-
-            // Enforce that when adding two variables, operands must both be of type number or of type string
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/restrict-plus-operands.md
-            '@typescript-eslint/restrict-plus-operands': [
-              'error',
-              {
-                checkCompoundAssignments: true,
-              },
-            ],
-
-            // Enforce optional chaining over chaining AND (&&) operators
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-optional-chain.md
-            '@typescript-eslint/prefer-optional-chain': 'warn',
-
-            // Enforce optional chaining over chaining AND (&&) operators
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-non-null-asserted-optional-chain.md
-            '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
-
-            // Enforce nullish coalescing over short-circuiting
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
-            '@typescript-eslint/prefer-nullish-coalescing': [
-              'warn',
-              {
-                ignoreConditionalTests: true,
-                ignoreMixedLogicalExpressions: true,
-                forceSuggestionFixer: false,
-              },
-            ],
-
-            // Prefer usage of as const over literal type
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-as-const.md
-            // TODO: turn it on when 2.18.x is out
-            // '@typescript-eslint/prefer-as-const': 'error',
-
-            // Prevent unnecessary type arguments
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-type-arguments.md
-            '@typescript-eslint/no-unnecessary-type-arguments': 'warn',
-
-            // Warns when a namespace qualifier is unnecessary
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-qualifier.md
-            '@typescript-eslint/no-unnecessary-qualifier': 'warn',
-
-            // Disallow throwing literals as exceptions
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-throw-literal.md
-            '@typescript-eslint/no-throw-literal': 'warn',
-
-            // Disallows invocation of require() in favor of import statements
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-require-imports.md
-            '@typescript-eslint/no-require-imports': 'warn',
-
-            // Disallows the use of eval()-like methods
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-implied-eval.md
-            '@typescript-eslint/no-implied-eval': 'error',
-
-            // Requires Array#sort calls to always provide a compareFunction
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/require-array-sort-compare.md
-            '@typescript-eslint/require-array-sort-compare': 'error',
-
             //! extensions of native eslint rules
             //! when modifying a rule here, make sure to modify the native one and vice-versa
+
+            // Disallow declaration of variables already declared in the outer scope
+            // https://eslint.org/docs/rules/no-shadow
+            'no-shadow': 'off',
+            '@typescript-eslint/no-shadow': [
+              'error',
+              {
+                allow: ['done', 'next', 'resolve', 'reject', 'cb'],
+              },
+            ],
 
             // Prevent unused declared variables
             // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md
@@ -225,6 +140,100 @@ module.exports = !hasTypescript
                 typedefs: false,
               },
             ],
+            // ! ts only rules
+            // Enforce explicit accessibility modifiers on class properties and methods
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md
+            '@typescript-eslint/explicit-member-accessibility': [
+              'error',
+              {
+                accessibility: 'explicit',
+                overrides: {
+                  accessors: 'explicit',
+                  constructors: 'no-public',
+                  methods: 'explicit',
+                  parameterProperties: 'explicit',
+                },
+              },
+            ],
+
+            // Enforce explicit function return type
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+            '@typescript-eslint/explicit-function-return-type': 'off',
+
+            // Enforce a consistent way of typing arrays
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.mdv
+            '@typescript-eslint/array-type': [
+              'warn',
+              {
+                default: 'array-simple',
+                readonly: 'array-simple',
+              },
+            ],
+
+            // Enforce a consitent way to type objects
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-definitions.md
+            '@typescript-eslint/consistent-type-definitions': 'off',
+
+            // Disallow non null assertions (!), comes from the recommended config
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-non-null-assertion.md
+            '@typescript-eslint/no-non-null-assertion': 'warn',
+
+            // Enforce that when adding two variables, operands must both be of type number or of type string
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/restrict-plus-operands.md
+            '@typescript-eslint/restrict-plus-operands': [
+              'error',
+              {
+                checkCompoundAssignments: true,
+              },
+            ],
+
+            // Enforce optional chaining over chaining AND (&&) operators
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-optional-chain.md
+            '@typescript-eslint/prefer-optional-chain': 'warn',
+
+            // Enforce optional chaining over chaining AND (&&) operators
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-non-null-asserted-optional-chain.md
+            '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
+
+            // Enforce nullish coalescing over short-circuiting
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
+            '@typescript-eslint/prefer-nullish-coalescing': [
+              'warn',
+              {
+                ignoreConditionalTests: true,
+                ignoreMixedLogicalExpressions: true,
+                forceSuggestionFixer: false,
+              },
+            ],
+
+            // Prefer usage of as const over literal type
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-as-const.md
+            // TODO: turn it on when 2.18.x is out
+            // '@typescript-eslint/prefer-as-const': 'error',
+
+            // Prevent unnecessary type arguments
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-type-arguments.md
+            '@typescript-eslint/no-unnecessary-type-arguments': 'warn',
+
+            // Warns when a namespace qualifier is unnecessary
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-qualifier.md
+            '@typescript-eslint/no-unnecessary-qualifier': 'warn',
+
+            // Disallow throwing literals as exceptions
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-throw-literal.md
+            '@typescript-eslint/no-throw-literal': 'warn',
+
+            // Disallows invocation of require() in favor of import statements
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-require-imports.md
+            '@typescript-eslint/no-require-imports': 'warn',
+
+            // Disallows the use of eval()-like methods
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-implied-eval.md
+            '@typescript-eslint/no-implied-eval': 'error',
+
+            // Requires Array#sort calls to always provide a compareFunction
+            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/require-array-sort-compare.md
+            '@typescript-eslint/require-array-sort-compare': 'error',
 
             // Enforce explicit enum item values
             // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-enum-initializers.md

--- a/packages/eslint-plugin-vtex/package.json
+++ b/packages/eslint-plugin-vtex/package.json
@@ -41,6 +41,6 @@
     "jest": "^24.8.0"
   },
   "peerDependencies": {
-    "eslint": "^6.0.0 || ^7.0.0"
+    "eslint": "^6 || ^7"
   }
 }

--- a/packages/eslint-plugin-vtex/package.json
+++ b/packages/eslint-plugin-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-vtex",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "VTEX's ESLint plugin",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
#### What is the purpose of this pull request?

- New rule to prevent unnecessary type definitions.
- New rule to enforce consistency for type-only imports
- Enable `no-shadow` for ts.