### PR TITLE
Feat/curly convention

### DIFF
--- a/packages/eslint-config-vtex-react/CHANGELOG.md
+++ b/packages/eslint-config-vtex-react/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Move hooks config to `react-hooks` file.
+
 ## 6.8.6 - 2020-12-03
 ### Fixed
 - Add `env.browser: true` to react preset.

--- a/packages/eslint-config-vtex-react/CHANGELOG.md
+++ b/packages/eslint-config-vtex-react/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 6.9.0 - 2020-12-09
 ### Changed
 - Move hooks config to `react-hooks` file.
 

--- a/packages/eslint-config-vtex-react/package.json
+++ b/packages/eslint-config-vtex-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex-react",
-  "version": "6.8.7",
+  "version": "6.9.0",
   "description": "VTEX's eslint config for React",
   "main": "index.js",
   "scripts": {
@@ -36,7 +36,7 @@
     "directory": "packages/eslint-config-vtex-react"
   },
   "dependencies": {
-    "eslint-config-vtex": "^12.8.14",
+    "eslint-config-vtex": "^12.9.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.6",
     "eslint-plugin-react-hooks": "^4.1.0"

--- a/packages/eslint-config-vtex-react/rules/react-a11y.js
+++ b/packages/eslint-config-vtex-react/rules/react-a11y.js
@@ -1,7 +1,7 @@
 // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/
 module.exports = {
   extends: ['plugin:jsx-a11y/recommended'],
-  plugins: ['jsx-a11y', 'react'],
+  plugins: ['jsx-a11y'],
   parserOptions: {
     ecmaFeatures: {
       jsx: true,

--- a/packages/eslint-config-vtex-react/rules/react-hooks.js
+++ b/packages/eslint-config-vtex-react/rules/react-hooks.js
@@ -1,4 +1,6 @@
 module.exports = {
+  extends: ['plugin:react-hooks/recommended'],
+  plugins: ['react-hooks'],
   rules: {
     // Enforce Rules of Hooks
     // https://github.com/facebook/react/blob/c11015ff4f610ac2924d1fc6d569a17657a404fd/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js

--- a/packages/eslint-config-vtex-react/rules/react.js
+++ b/packages/eslint-config-vtex-react/rules/react.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['plugin:react/recommended', 'prettier/react'],
-  plugins: ['react', 'react-hooks'],
+  plugins: ['react'],
   parserOptions: {
     ecmaFeatures: {
       jsx: true,

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 12.9.0 - 2020-12-09
 ### Added
 - Add convention for multi-line statements after ifs, whiles, fors, etc.
 

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add convention for multi-line statements after ifs, whiles, fors, etc.
+
 ## 12.8.14 - 2020-12-04
 ### Changed
 - Allow to use `import()` for type annotations.

--- a/packages/eslint-config-vtex/index.js
+++ b/packages/eslint-config-vtex/index.js
@@ -2,6 +2,7 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:vtex/recommended',
+    './rules/prettier.js',
     './rules/errors.js',
     './rules/node.js',
     './rules/style.js',
@@ -9,7 +10,6 @@ module.exports = {
     './rules/best-practices.js',
     './rules/imports.js',
     './rules/typescript.js',
-    './rules/prettier.js',
     './rules/tests.js',
   ],
   plugins: ['vtex'],

--- a/packages/eslint-config-vtex/package.json
+++ b/packages/eslint-config-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex",
-  "version": "12.8.14",
+  "version": "12.9.0",
   "description": "VTEX's eslint config",
   "main": "index.js",
   "scripts": {

--- a/packages/eslint-config-vtex/rules/style.js
+++ b/packages/eslint-config-vtex/rules/style.js
@@ -1,5 +1,10 @@
 module.exports = {
   rules: {
+    // Allow brace-less single-line if, else if, else, for, while, or do, while still enforcing the use of curly braces for other instances.
+    // ! Overrides definition on 'eslint-config-prettier'
+    // https://eslint.org/docs/rules/curly
+    curly: ['error', 'multi-line'],
+
     // Require camel case names
     // https://eslint.org/docs/rules/camelcase
     camelcase: [


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adds a convention for adding curly braces around multi-line statements after ifs, whiles, fors, etc.

See https://vtex.slack.com/archives/CSKQK8T6G/p1607451619044500

>Something that bothers me now and then is when you have a multiline brace-less statement after an if. 
> I think it’s a bit harder to detect where the if block begins and where it ends. Does someone else also have opinions about this? I was looking for a possible solution and found the curly rule with the multiline parameter: https://eslint.org/docs/rules/curly#multi-line
It accepts single-liners, but if a statement has more than one line, it enforces it to be between curly braces.