### PR TITLE
Use eslint-plugin-node instead of deprecated rules

### DIFF
--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use `eslint-plugin-node` instead of deprecated native node rules.
+
+### Added
+- Encourage usage of Promise API for `fs` and `dns` node modules.
 
 ## [12.9.5] - 2021-03-15
 ### Fixed
@@ -25,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## 12.9.0 - 2020-12-09
 ### Added
 - Add convention for multi-line statements after ifs, whiles, fors, etc.
+
 
 ## 12.8.14 - 2020-12-04
 ### Changed

--- a/packages/eslint-config-vtex/lib/utils.js
+++ b/packages/eslint-config-vtex/lib/utils.js
@@ -1,4 +1,4 @@
-/* eslint-disable global-require */
+/* eslint-disable node/global-require */
 
 exports.hasPackage = (pkg) => {
   try {

--- a/packages/eslint-config-vtex/package.json
+++ b/packages/eslint-config-vtex/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-cypress": "^2.11.2",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.1.3",
+    "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-vtex": "^2.0.10"
   },

--- a/packages/eslint-config-vtex/rules/node.js
+++ b/packages/eslint-config-vtex/rules/node.js
@@ -1,28 +1,42 @@
 module.exports = {
+  plugins: ['node'],
   env: {
     node: true,
   },
   rules: {
     // Disallow use of process.env
-    // https://eslint.org/docs/rules/no-process-env
-    'no-process-env': 'off',
+    // https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-process-env.md
+    'node/no-process-env': 'off',
 
     // Enforce a callback to return
-    // https://eslint.org/docs/rules/callback-return
-    //! maybe too annoying
-    'callback-return': 'off',
+    // https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/callback-return.md
+    //! too annoying
+    'node/callback-return': 'off',
 
     // Require all requires be top-level
-    // https://eslint.org/docs/rules/global-require
-    // TODO https://github.com/vtex/front-end-coding-standard/issues/28
-    'global-require': 'error',
+    // https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/global-require.md
+    'node/global-require': 'error',
 
     // Disallow use of new operator with the require function
-    // https://eslint.org/docs/rules/no-new-require
-    'no-new-require': 'error',
+    // https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-new-require.md
+    'node/no-new-require': 'error',
 
     // Disallow string concatenation with __dirname and __filename
-    // https://eslint.org/docs/rules/no-path-concat
-    'no-path-concat': 'error',
+    // https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-path-concat.md
+    'node/no-path-concat': 'error',
+
+    // Make process.exit() expressions the same code path as throw
+    // https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/process-exit-as-throw.md
+    'node/process-exit-as-throw': 'error',
+
+    // Disallow deprecated APIs
+    // https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-deprecated-api.md
+    'node/no-deprecated-api': 'error',
+
+    // Encourages use of promise APIs instead o callback APIs
+    // https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/prefer-promises/fs.md
+    // https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/prefer-promises/dns.md
+    'node/prefer-promises/fs': 'warn',
+    'node/prefer-promises/dns': 'warn',
   },
 }

--- a/packages/eslint-plugin-vtex/index.js
+++ b/packages/eslint-plugin-vtex/index.js
@@ -1,4 +1,5 @@
-/* eslint-disable global-require */
+/* eslint-disable node/global-require */
+
 module.exports = {
   configs: {
     recommended: require('./lib/configs/recommended.js'),


### PR DESCRIPTION
#### What is the purpose of this pull request?

Eslint 7 deprecated node-specific rules in favor of the `eslint-plugin-node`. This PR aims to use the new rules and add some new ones.

This could be a minor change, although a few projects disable the `global-require` rule. Changing to the rule namespaced with `node/` would start throwing an error since the disabled rule has another name.

This is going to bump the major of `eslint-config-vtex` and `eslint-config-vtex-react` and folk will need to manually update the version in an existing project. However, it should be a simple enough thing to update.

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
