### PR TITLE
Fix ban-ts-comment configuration by updating the "@typescript-eslint/eslint-plugin" dependency

### DIFF
--- a/packages/eslint-config-vtex-react/CHANGELOG.md
+++ b/packages/eslint-config-vtex-react/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [6.9.4] - 2021-01-29
 ### Changed
 - Update typescript-eslint dependencies
 
@@ -117,7 +119,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for typescript by extending `eslint-config-vtex` v10.
 - Add more rules for a11y in components.
 
-[Unreleased]: https://github.com/vtex/javascript/compare/v6.2.1...HEAD
+[Unreleased]: https://github.com/vtex/typescript/compare/v6.9.4...HEAD
+[6.9.4]: https://github.com/vtex/typescript/compare/v6.9.1...v6.9.4
 [6.2.1]: https://github.com/vtex/javascript/compare/v6.2.0...v6.2.1
 [6.2.0]: https://github.com/vtex/javascript/compare/v6.1.1...v6.2.0
 [6.1.1]: https://github.com/vtex/javascript/compare/v6.0.3...v6.1.1

--- a/packages/eslint-config-vtex-react/CHANGELOG.md
+++ b/packages/eslint-config-vtex-react/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update typescript-eslint dependencies
 
 ## 6.9.1 - 2020-12-09
 ### Fixed

--- a/packages/eslint-config-vtex-react/package.json
+++ b/packages/eslint-config-vtex-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex-react",
-  "version": "6.9.3",
+  "version": "6.9.4",
   "description": "VTEX's eslint config for React",
   "main": "index.js",
   "scripts": {
@@ -36,7 +36,7 @@
     "directory": "packages/eslint-config-vtex-react"
   },
   "dependencies": {
-    "eslint-config-vtex": "^12.9.3",
+    "eslint-config-vtex": "^12.9.4",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.6",
     "eslint-plugin-react-hooks": "^4.1.0"

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update typescript-eslint dependencies
 
 ## 12.9.3 - 2020-12-16
 ### Fixed

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [12.9.4] - 2021-01-29
 ### Changed
 - Update typescript-eslint dependencies
 
@@ -206,7 +208,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Lodash rules and prettier configs.
 
-[Unreleased]: https://github.com/vtex/typescript/compare/v12.3.2...HEAD
+[Unreleased]: https://github.com/vtex/typescript/compare/v12.9.4...HEAD
+[12.9.4]: https://github.com/vtex/typescript/compare/v12.9.3...v12.9.4
 [12.3.2]: https://github.com/vtex/typescript/compare/v12.3.1...v12.3.2
 [12.2.1]: https://github.com/vtex/javascript/compare/v12.2.0...v12.2.1
 [12.2.0]: https://github.com/vtex/javascript/compare/v12.1.0...v12.2.0

--- a/packages/eslint-config-vtex/package.json
+++ b/packages/eslint-config-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex",
-  "version": "12.9.3",
+  "version": "12.9.4",
   "description": "VTEX's eslint config",
   "main": "index.js",
   "scripts": {

--- a/packages/eslint-config-vtex/package.json
+++ b/packages/eslint-config-vtex/package.json
@@ -33,8 +33,8 @@
     "lib/"
   ],
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.8.1",
-    "@typescript-eslint/parser": "^4.8.1",
+    "@typescript-eslint/eslint-plugin": "^4.14.1",
+    "@typescript-eslint/parser": "^4.14.1",
     "confusing-browser-globals": "^1.0.9",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-cypress": "^2.11.2",


### PR DESCRIPTION
Currently we have a bug about ban-ts-comment configuration and the current "@typescript-eslint/eslint-plugin"

https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/ban-ts-comment.md

#### What problem is this solving?

To Fix this bug:

```
Oops! Something went wrong! :(

ESLint: 7.18.0

Error: .eslintrc » eslint-config-vtex » ./rules/typescript.js#overrides[0]:
	Configuration for rule "@typescript-eslint/ban-ts-comment" is invalid:
	Value {"ts-expect-error":"allow-with-description","ts-ignore":true,"ts-nocheck":true,"ts-check":false,"minimumDescriptionLength":3} should NOT have additional properties.
```

#### How should this be manually tested?

By testing if the current eslint rules still work

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
