### PR TITLE
Fix conflict between padding-line-between-statements and import/order

### DIFF
--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `padding-line-between-statements` doesn't forces lines between cjs-import, import/order already handle them
 
 ## [12.9.4] - 2021-01-29
 ### Changed

--- a/packages/eslint-config-vtex/rules/style.js
+++ b/packages/eslint-config-vtex/rules/style.js
@@ -182,6 +182,13 @@ module.exports = {
         prev: ['function', 'class', 'multiline-block-like'],
         next: '*',
       },
+      // import/order already handle padding lines between cjs-imports
+      // see https://github.com/vtex/typescript/issues/82
+      {
+        blankLine: 'any',
+        prev: ['cjs-import'],
+        next: ['cjs-import'],
+      },
     ],
 
     // Require or disallow padding lines between class members


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix #82

#### How should this be manually tested?

This code should be valid for our current rules:

```ts
const {
  FirstPropertyBreakingIndent,
  SecondPropertyBreakingIndent,
} = require('./a')
const b = require('./b')

console.warn(FirstPropertyBreakingIndent, SecondPropertyBreakingIndent, b)
```

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
