### PR TITLE
chore: update deps of eslint-config-vtex/eslint-config-vtex-react

### DIFF
--- a/packages/eslint-config-vtex-react/CHANGELOG.md
+++ b/packages/eslint-config-vtex-react/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `eslint-config-prettier` updated 6.15.0 to 8.1.0
+- Requires at least ESLint 7.0.0 now, because `eslint-config-prettier` drops support for ESLint 6, [see here](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-700-2020-12-05)
+
 ## [6.9.4] - 2021-01-29
 ### Changed
 - Update typescript-eslint dependencies

--- a/packages/eslint-config-vtex-react/package.json
+++ b/packages/eslint-config-vtex-react/package.json
@@ -4,8 +4,8 @@
   "description": "VTEX's eslint config for React",
   "main": "index.js",
   "scripts": {
-    "eslint-check": "eslint --print-config index.js | eslint-config-prettier-check",
-    "dump-config": "eslint --print-config index.js > config-dump.json",
+    "eslint-check": "eslint-config-prettier index.js",
+    "dump-config": "eslint-config-prettier index.js > config-dump.json",
     "version": "chan release $npm_package_version && git add CHANGELOG.md"
   },
   "files": [
@@ -42,7 +42,7 @@
     "eslint-plugin-react-hooks": "^4.1.0"
   },
   "peerDependencies": {
-    "eslint": "^6 || ^7",
+    "eslint": "^7",
     "prettier": "^1.18.2 || ^2.0.4",
     "typescript": "^3.8 || ^4.0.0"
   }

--- a/packages/eslint-config-vtex-react/rules/react.js
+++ b/packages/eslint-config-vtex-react/rules/react.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['plugin:react/recommended', 'prettier/react'],
+  extends: ['plugin:react/recommended'],
   plugins: ['react'],
   parserOptions: {
     ecmaFeatures: {

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `eslint-config-prettier` updated 6.15.0 to 8.1.0
+- Requires at least ESLint 7.0.0 now, because `eslint-config-prettier` drops support for ESLint 6, [see here](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-700-2020-12-05)
+
 ## [13.0.0] - 2021-03-16
 ### Changed
 - Use `eslint-plugin-node` instead of deprecated native node rules.

--- a/packages/eslint-config-vtex/package.json
+++ b/packages/eslint-config-vtex/package.json
@@ -4,8 +4,8 @@
   "description": "VTEX's eslint config",
   "main": "index.js",
   "scripts": {
-    "eslint-check": "eslint --print-config index.js | eslint-config-prettier-check",
-    "dump-config": "eslint --print-config index.js > config-dump.json",
+    "eslint-check": "eslint-config-prettier index.js",
+    "dump-config": "eslint-config-prettier index.js > config-dump.json",
     "version": "chan release $npm_package_version && git add CHANGELOG.md"
   },
   "keywords": [
@@ -33,19 +33,19 @@
     "lib/"
   ],
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.14.1",
-    "@typescript-eslint/parser": "^4.14.1",
-    "confusing-browser-globals": "^1.0.9",
-    "eslint-config-prettier": "^6.15.0",
+    "@typescript-eslint/eslint-plugin": "^4.18.0",
+    "@typescript-eslint/parser": "^4.18.0",
+    "confusing-browser-globals": "^1.0.10",
+    "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-cypress": "^2.11.2",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jest": "^24.1.3",
+    "eslint-plugin-jest": "^24.3.2",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-vtex": "^2.0.11"
   },
   "peerDependencies": {
-    "eslint": "^6 || ^7",
+    "eslint": "^7",
     "prettier": "^1 || ^2",
     "typescript": "^3 || ^4"
   }

--- a/packages/eslint-config-vtex/rules/best-practices.js
+++ b/packages/eslint-config-vtex/rules/best-practices.js
@@ -89,7 +89,8 @@ module.exports = {
 
     // Disallow the use of leading or trailing decimal points in numeric literals
     // https://eslint.org/docs/rules/no-floating-decimal
-    'no-floating-decimal': 'error',
+    // Disabled because prettier already handle this rule
+    'no-floating-decimal': 'off',
 
     // Disallow reassignments of native objects or read-only globals
     // https://eslint.org/docs/rules/no-global-assign

--- a/packages/eslint-config-vtex/rules/style.js
+++ b/packages/eslint-config-vtex/rules/style.js
@@ -1,9 +1,10 @@
 module.exports = {
   rules: {
     // Allow brace-less single-line if, else if, else, for, while, or do, while still enforcing the use of curly braces for other instances.
-    // ! Overrides definition on 'eslint-config-prettier'
     // https://eslint.org/docs/rules/curly
-    curly: ['error', 'multi-line', 'consistent'],
+    // Disabled because conflicts with prettier
+    // https://github.com/prettier/eslint-config-prettier#curly
+    curly: 'off',
 
     // Require camel case names
     // https://eslint.org/docs/rules/camelcase

--- a/packages/eslint-config-vtex/rules/typescript.js
+++ b/packages/eslint-config-vtex/rules/typescript.js
@@ -11,7 +11,6 @@ module.exports = !hasTypescript
           extends: [
             'plugin:@typescript-eslint/eslint-recommended',
             'plugin:@typescript-eslint/recommended',
-            'prettier/@typescript-eslint',
           ],
           plugins: ['@typescript-eslint'],
           parser: '@typescript-eslint/parser',


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Upgrade dependencies of `eslint-config-vtex` and `eslint-config-vtex-react`
  - `eslint-config-prettier@7.0.0` introduced a breaking changing, because [it dropped support for ESLint 7<](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-700-2020-12-05). Seems like eslint@6.8.0 was the last minor version of 6.x and was published one year ago.
  - `eslint-config-prettier@8.0.0` also [merged all their configs into one](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
