### PR TITLE
Optimize parsing of typescript files being lint on monorepo in terms of memory

### DIFF
--- a/packages/eslint-config-vtex-react/package.json
+++ b/packages/eslint-config-vtex-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex-react",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "VTEX's eslint config for React",
   "main": "index.js",
   "scripts": {
@@ -36,7 +36,7 @@
     "directory": "packages/eslint-config-vtex-react"
   },
   "dependencies": {
-    "eslint-config-vtex": "^14.0.0",
+    "eslint-config-vtex": "^14.1.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.6",
     "eslint-plugin-react-hooks": "^4.1.0"

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [14.1.0] - 2021-06-24
 ### Fixed
 - Fix OOM on monorepos by optmizing parsing of typescript files
 
@@ -226,7 +228,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Lodash rules and prettier configs.
 
-[Unreleased]: https://github.com/vtex/typescript/compare/v14.0.0...HEAD
+[Unreleased]: https://github.com/vtex/typescript/compare/v14.1.0...HEAD
+[14.1.0]: https://github.com/vtex/typescript/compare/v14.0.0...v14.1.0
 [14.0.0]: https://github.com/vtex/typescript/compare/v13.0.0...v14.0.0
 [13.0.0]: https://github.com/vtex/typescript/compare/v12.9.5...v13.0.0
 [12.9.5]: https://github.com/vtex/typescript/compare/v12.9.4...v12.9.5

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix OOM on monorepos by optmizing parsing of typescript files
 
 ## [14.0.0] - 2021-03-25
 ### Changed

--- a/packages/eslint-config-vtex/package.json
+++ b/packages/eslint-config-vtex/package.json
@@ -33,8 +33,8 @@
     "lib/"
   ],
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.18.0",
-    "@typescript-eslint/parser": "^4.18.0",
+    "@typescript-eslint/eslint-plugin": "^4.28.0",
+    "@typescript-eslint/parser": "^4.28.0",
     "confusing-browser-globals": "^1.0.10",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-cypress": "^2.11.2",

--- a/packages/eslint-config-vtex/package.json
+++ b/packages/eslint-config-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vtex",
-  "version": "14.0.0",
+  "version": "14.1.0",
   "description": "VTEX's eslint config",
   "main": "index.js",
   "scripts": {
@@ -42,7 +42,7 @@
     "eslint-plugin-jest": "^24.3.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.3.1",
-    "eslint-plugin-vtex": "^2.0.11"
+    "eslint-plugin-vtex": "^2.1.0"
   },
   "peerDependencies": {
     "eslint": "^7",

--- a/packages/eslint-config-vtex/rules/typescript.js
+++ b/packages/eslint-config-vtex/rules/typescript.js
@@ -26,6 +26,7 @@ module.exports = !hasTypescript
               '*/*/tsconfig{.eslint.json,.json}',
             ],
             projectFolderIgnoreList: [/node_modules/i],
+            allowAutomaticSingleRunInference: true,
           },
           rules: {
             //! extensions of native eslint rules

--- a/packages/eslint-config-vtex/rules/typescript.js
+++ b/packages/eslint-config-vtex/rules/typescript.js
@@ -26,6 +26,8 @@ module.exports = !hasTypescript
               '*/*/tsconfig{.eslint.json,.json}',
             ],
             projectFolderIgnoreList: [/node_modules/i],
+            // We need this configuration to avoid performance issues in monorepos
+            // https://github.com/typescript-eslint/typescript-eslint/issues/1192#issuecomment-862414778
             allowAutomaticSingleRunInference: true,
           },
           rules: {

--- a/packages/eslint-plugin-vtex/CHANGELOG.md
+++ b/packages/eslint-plugin-vtex/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.1.0] - 2021-06-24
 ### Fixed
 - Fix OOM on monorepos by optmizing parsing of typescript files
 
@@ -44,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Missing files in packages.
 
-[Unreleased]: https://github.com/vtex/js-standards/compare/v1.0.3...HEAD
+[Unreleased]: https://github.com/vtex/typescript/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/vtex/typescript/compare/v2.0.6...v2.1.0
 [1.0.3]: https://github.com/vtex/js-standards/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/vtex/js-standards/compare/v1.0.1...v1.0.2

--- a/packages/eslint-plugin-vtex/CHANGELOG.md
+++ b/packages/eslint-plugin-vtex/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix OOM on monorepos by optmizing parsing of typescript files
 
 ## 2.0.6 - 2020-11-18
 ### Changed

--- a/packages/eslint-plugin-vtex/package.json
+++ b/packages/eslint-plugin-vtex/package.json
@@ -36,8 +36,8 @@
     "collectCoverage": false
   },
   "devDependencies": {
-    "@typescript-eslint/experimental-utils": "^4.8.1",
-    "@typescript-eslint/parser": "^4.8.1",
+    "@typescript-eslint/experimental-utils": "^4.28.0",
+    "@typescript-eslint/parser": "^4.28.0",
     "jest": "^24.8.0"
   },
   "peerDependencies": {

--- a/packages/eslint-plugin-vtex/package.json
+++ b/packages/eslint-plugin-vtex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-vtex",
-  "version": "2.0.11",
+  "version": "2.1.0",
   "description": "VTEX's ESLint plugin",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix eslint on typescript files on monorepo, see: https://github.com/typescript-eslint/typescript-eslint/issues/1192#issuecomment-862414778

#### How should this be manually tested?

By running tests and linter on this project and see it continues to work.

I also sent a beta tag and tested on instore-core (https://github.com/vtex/instore-core/pull/78)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
