### PR TITLE
Add forceConsistentCasingInFileNames property to tsconfig

### DIFF
--- a/packages/tsconfig/CHANGELOG.md
+++ b/packages/tsconfig/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `forceConsistentCasingInFileNames` property. 
 
 ## 0.5.5 - 2020-11-19
 ### Fixed

--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -17,7 +17,8 @@
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
-    "target": "es2017"
+    "target": "es2017",
+    "forceConsistentCasingInFileNames": true
   },
   "typeAcquisition": {
     "enable": false


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PRs add the [forceConsistentCasingInFileNames](https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames) property to tsconfig settings.

#### What problem is this solving?
Prevents imports with wrong filenames on systems that are case insensitive.

#### How should this be manually tested?
On MacOS, you can follow these steps:
1. create a file `Foo.ts` and export default something. Yeah, with upper `F`
2. into another file, write `import Foo from 'foo'` with  lower `f`
3. TS server will throw an error.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/15680320/125848443-42d7517c-65a2-431a-880f-909805f0c5c1.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
