### PR TITLE
Configure @vtex/eslint-plugin-admin-ui

### DIFF
--- a/packages/eslint-config-vtex-react/index.js
+++ b/packages/eslint-config-vtex-react/index.js
@@ -1,6 +1,8 @@
 module.exports = {
+  plugins: ['@vtex/admin-ui'],
   extends: [
     'eslint-config-vtex',
+    'plugin:@vtex/admin-ui/recommended',
     './rules/react.js',
     './rules/react-hooks.js',
     './rules/react-a11y.js',

--- a/packages/eslint-config-vtex-react/package.json
+++ b/packages/eslint-config-vtex-react/package.json
@@ -36,6 +36,7 @@
     "directory": "packages/eslint-config-vtex-react"
   },
   "dependencies": {
+    "@vtex/eslint-plugin-admin-ui": "^0.2.9",
     "eslint-config-vtex": "^14.1.1",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.6",


### PR DESCRIPTION
#### What is the purpose of this pull request? / What problem is this solving?

- Install our new plugin `@vtex/eslint-plugin-admin-ui` and configure it to use the recommended settings

#### How should this be manually tested?

- You can locally change the `packages/eslint-config-vtex-react/demo/Component.tsx` to some breaking rule like [@vtex/admin-ui/create-tag-component-outside-render-phase](https://github.com/vtex/onda/blob/master/packages/eslint-plugin-admin-ui/docs/rules/create-tag-component-outside-render-phase.md) to see it complains

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
