### PR TITLE
Upgrade typescript-eslint and prettier plugin dependencies

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -19,14 +19,10 @@
     "format:check": "prettier --list-different \"./**/*.{ts,js,json}\"",
     "format": "prettier --write \"**/*.{ts,js,json}\"",
     "lint": "eslint --ext .js,.ts,.jsx,.tsx .",
-    "test": "lerna run test --concurrency 1"
+    "test": "lerna run test --concurrency 1",
+    "prepare": "husky install"
   },
   "prettier": "@vtex/prettier-config",
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
   "lint-staged": {
     "*.{ts,js}": [
       "eslint --fix",
@@ -38,11 +34,11 @@
   },
   "devDependencies": {
     "@geut/chan": "^2.1.1",
-    "eslint": "^7.14.0",
-    "husky": "^4.3.0",
+    "eslint": "^8.11.0",
+    "husky": "^7.0.0",
     "lerna": "^3.18.4",
-    "lint-staged": "^10.5.2",
+    "lint-staged": "^12.3.5",
     "prettier": "^2.2.0",
-    "typescript": "^3.8"
+    "typescript": "^4.6.2"
   }
 }

--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **BREAKING CHANGE** Upgrades `@typescript-eslint` dependencies to major 5.
+- **BREAKING CHANGE** Upgrades `eslint-plugin-prettier` to major 4, and bumps
+  `prettier` peer dependency to only target major 2.
+- **BREAKING CHANGE** Updates peer dependency on `eslint` to only target major 8.
 
 ## [14.1.1] - 2021-08-17
 ### Changed

--- a/packages/eslint-config-vtex/package.json
+++ b/packages/eslint-config-vtex/package.json
@@ -33,20 +33,20 @@
     "lib/"
   ],
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.29.2",
-    "@typescript-eslint/parser": "^4.29.2",
+    "@typescript-eslint/eslint-plugin": "^5.15.0",
+    "@typescript-eslint/parser": "^5.15.0",
     "confusing-browser-globals": "^1.0.10",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-cypress": "^2.11.2",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jest": "^24.3.2",
+    "eslint-plugin-jest": "^26.1.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^3.3.1",
+    "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-vtex": "^2.1.2"
   },
   "peerDependencies": {
-    "eslint": "^7",
-    "prettier": "^1 || ^2",
+    "eslint": "^8",
+    "prettier": "^2",
     "typescript": "^3 || ^4"
   }
 }

--- a/packages/eslint-config-vtex/rules/tests.js
+++ b/packages/eslint-config-vtex/rules/tests.js
@@ -1,4 +1,5 @@
-// Jest: https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules
+// Jest:
+// https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules
 // Cypress: https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules
 const { hasPackage } = require('../lib/utils')
 
@@ -53,10 +54,6 @@ module.exports = {
         // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-duplicate-hooks.md
         'jest/no-duplicate-hooks': 'error',
 
-        // Disallow using expect().resolves
-        // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-expect-resolves.md
-        'jest/no-expect-resolves': 'error',
-
         // Suggest to have all hooks at top-level before tests
         // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-hooks-on-top.md
         'jest/prefer-hooks-on-top': 'error',
@@ -78,11 +75,6 @@ module.exports = {
         // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-test-return-statement.md
         // TODO: enable?
         'jest/no-test-return-statement': 'off',
-
-        // Disallow toBeTruthy() and toBeFalsy()
-        // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-truthy-falsy.md
-        // TODO: enable?
-        'jest/no-truthy-falsy': 'off',
 
         // Disallow deprecated jest functions
         // https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-deprecated-functions.md

--- a/packages/eslint-plugin-vtex/CHANGELOG.md
+++ b/packages/eslint-plugin-vtex/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Include `eslint` major 8 in peer dependencies range.
 
 ## [2.1.0] - 2021-06-24
 ### Fixed

--- a/packages/eslint-plugin-vtex/package.json
+++ b/packages/eslint-plugin-vtex/package.json
@@ -36,11 +36,11 @@
     "collectCoverage": false
   },
   "devDependencies": {
-    "@typescript-eslint/experimental-utils": "^4.28.0",
-    "@typescript-eslint/parser": "^4.28.0",
-    "jest": "^24.8.0"
+    "@typescript-eslint/experimental-utils": "^5.15.0",
+    "@typescript-eslint/parser": "^5.15.0",
+    "jest": "^27.5.1"
   },
   "peerDependencies": {
-    "eslint": "^6 || ^7"
+    "eslint": "^6 || ^7 || ^8"
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Updates the dependencies of `eslint-config-vtex` to their latest versions. Also updates a few dev dependencies on this repo just to shave off a bit of the technical debt.

#### What problem is this solving?

The latest version of major 4 of `typescript-eslint` doesn't play well with eslint 8 and the latest version of typescript.

#### How should this be manually tested?

I just ran `yarn test` and it seemed to be ok, although it only run the tests on `eslint-plugin-vtex`. I don't know how else to test this other than to verify the version is ok after publishing it to NPM and testing locally on a package.

I'm up for suggestions.

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
