### PR TITLE
Remove option that no longer exists

### DIFF
--- a/packages/eslint-config-vtex/CHANGELOG.md
+++ b/packages/eslint-config-vtex/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+- Option `forceSuggestionFixer` that no longer exists.
+
 ## [15.0.0] - 2022-03-15
 ### Changed
 - **BREAKING CHANGE** Upgrades `@typescript-eslint` dependencies to major 5.

--- a/packages/eslint-config-vtex/rules/typescript.js
+++ b/packages/eslint-config-vtex/rules/typescript.js
@@ -204,7 +204,6 @@ module.exports = !hasTypescript
               {
                 ignoreConditionalTests: true,
                 ignoreMixedLogicalExpressions: true,
-                forceSuggestionFixer: false,
               },
             ],
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

The option `forceSuggestionFixer` doesn't exist [according to the docs](https://typescript-eslint.io/rules/prefer-nullish-coalescing/), and it's causing an error when trying to run eslint.

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
