### PR TITLE
Fix link to docs of typescript-eslint rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @vtex/front-end-dx-guild

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,7 @@
-#### What is the purpose of this pull request?
+## Summary
 
-<!--- Describe your changes in detail. -->
+<!-- Write here a brief summary of your proposed changes -->
 
-#### What problem is this solving?
+## How to test
 
-<!--- What is the motivation and context for this change? -->
-
-#### How should this be manually tested?
-
-#### Screenshots or example usage
-
-#### Types of changes
-
-- [ ] Bug fix (a non-breaking change which fixes an issue)
-- [ ] New feature (a non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
-- [ ] Requires change to documentation, which has been updated accordingly.
+<!-- How do you test these changes? -->

--- a/packages/eslint-config-vtex/README.md
+++ b/packages/eslint-config-vtex/README.md
@@ -79,6 +79,6 @@ Please check the [`babel-eslint` documentation](https://github.com/babel/babel-e
 
 ## References
 
-- [`@typescript-eslint` documentation](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/README.md)
+- [`@typescript-eslint` documentation](https://typescript-eslint.io/docs/)
 - [`eslint-plugin-import` documentation](https://github.com/benmosher/eslint-plugin-import)
 - [`eslint-plugin-prettier` documentation](https://github.com/prettier/eslint-plugin-prettier)

--- a/packages/eslint-config-vtex/rules/typescript.js
+++ b/packages/eslint-config-vtex/rules/typescript.js
@@ -45,7 +45,7 @@ module.exports = !hasTypescript
             ],
 
             // Prevent unused declared variables
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md
+            // https://typescript-eslint.io/rules/no-unused-vars/
             'no-unused-vars': 'off',
             '@typescript-eslint/no-unused-vars': [
               'warn',
@@ -56,7 +56,7 @@ module.exports = !hasTypescript
             ],
 
             // Disallows the use of eval()-like methods
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-magic-numbers.md
+            // https://typescript-eslint.io/rules/no-magic-numbers/
             // TODO enable? maybe too much
             'no-magic-numbers': 'off',
             '@typescript-eslint/no-magic-numbers': [
@@ -72,12 +72,12 @@ module.exports = !hasTypescript
             ],
 
             // Enforce parameters with default values to be last
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/default-param-last.md
+            // https://typescript-eslint.io/rules/default-param-last/
             'default-param-last': 'off',
             '@typescript-eslint/default-param-last': 'error',
 
             // Disallow useless constructors
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-useless-constructor.md
+            // https://typescript-eslint.io/rules/no-useless-constructor/
             'no-useless-constructor': 'off',
             '@typescript-eslint/no-useless-constructor': 'error',
 
@@ -92,7 +92,7 @@ module.exports = !hasTypescript
             ],
 
             // Require a consistent naming convention
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md
+            // https://typescript-eslint.io/rules/naming-convention/
             camelcase: 'off',
             '@typescript-eslint/naming-convention': [
               'error',
@@ -130,7 +130,7 @@ module.exports = !hasTypescript
             ],
 
             // Disallow use of variables before they are defined
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-use-before-define.md
+            // https://typescript-eslint.io/rules/no-use-before-define/
             'no-use-before-define': 'off',
             '@typescript-eslint/no-use-before-define': [
               'error',
@@ -144,7 +144,7 @@ module.exports = !hasTypescript
             ],
             // ! ts only rules
             // Enforce explicit accessibility modifiers on class properties and methods
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md
+            // https://typescript-eslint.io/rules/explicit-member-accessibility/
             '@typescript-eslint/explicit-member-accessibility': [
               'error',
               {
@@ -159,11 +159,11 @@ module.exports = !hasTypescript
             ],
 
             // Enforce explicit function return type
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+            // https://typescript-eslint.io/rules/explicit-function-return-type/
             '@typescript-eslint/explicit-function-return-type': 'off',
 
             // Enforce a consistent way of typing arrays
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.mdv
+            // https://typescript-eslint.io/rules/array-type/v
             '@typescript-eslint/array-type': [
               'warn',
               {
@@ -173,15 +173,15 @@ module.exports = !hasTypescript
             ],
 
             // Enforce a consitent way to type objects
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-definitions.md
+            // https://typescript-eslint.io/rules/consistent-type-definitions/
             '@typescript-eslint/consistent-type-definitions': 'off',
 
             // Disallow non null assertions (!), comes from the recommended config
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-non-null-assertion.md
+            // https://typescript-eslint.io/rules/no-non-null-assertion/
             '@typescript-eslint/no-non-null-assertion': 'warn',
 
             // Enforce that when adding two variables, operands must both be of type number or of type string
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/restrict-plus-operands.md
+            // https://typescript-eslint.io/rules/restrict-plus-operands/
             '@typescript-eslint/restrict-plus-operands': [
               'error',
               {
@@ -190,15 +190,15 @@ module.exports = !hasTypescript
             ],
 
             // Enforce optional chaining over chaining AND (&&) operators
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-optional-chain.md
+            // https://typescript-eslint.io/rules/prefer-optional-chain/
             '@typescript-eslint/prefer-optional-chain': 'warn',
 
             // Enforce optional chaining over chaining AND (&&) operators
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-non-null-asserted-optional-chain.md
+            // https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/
             '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
 
             // Enforce nullish coalescing over short-circuiting
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
+            // https://typescript-eslint.io/rules/prefer-nullish-coalescing/
             '@typescript-eslint/prefer-nullish-coalescing': [
               'warn',
               {
@@ -208,49 +208,49 @@ module.exports = !hasTypescript
             ],
 
             // Prefer usage of as const over literal type
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-as-const.md
+            // https://typescript-eslint.io/rules/prefer-as-const/
             // TODO: turn it on when 2.18.x is out
             // '@typescript-eslint/prefer-as-const': 'error',
 
             // Prevent unnecessary type arguments
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-type-arguments.md
+            // https://typescript-eslint.io/rules/no-unnecessary-type-arguments/
             '@typescript-eslint/no-unnecessary-type-arguments': 'warn',
 
             // Warns when a namespace qualifier is unnecessary
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-qualifier.md
+            // https://typescript-eslint.io/rules/no-unnecessary-qualifier/
             '@typescript-eslint/no-unnecessary-qualifier': 'warn',
 
             // Disallow throwing literals as exceptions
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-throw-literal.md
+            // https://typescript-eslint.io/rules/no-throw-literal/
             '@typescript-eslint/no-throw-literal': 'warn',
 
             // Disallows invocation of require() in favor of import statements
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-require-imports.md
+            // https://typescript-eslint.io/rules/no-require-imports/
             '@typescript-eslint/no-require-imports': 'warn',
 
             // Disallows the use of eval()-like methods
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-implied-eval.md
+            // https://typescript-eslint.io/rules/no-implied-eval/
             '@typescript-eslint/no-implied-eval': 'error',
 
             // Requires Array#sort calls to always provide a compareFunction
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/require-array-sort-compare.md
+            // https://typescript-eslint.io/rules/require-array-sort-compare/
             '@typescript-eslint/require-array-sort-compare': 'error',
 
             // Enforce explicit enum item values
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-enum-initializers.md
+            // https://typescript-eslint.io/rules/prefer-enum-initializers/
             '@typescript-eslint/prefer-enum-initializers': 'warn',
 
             // Explicitly defines what a module scoped method returns
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md
+            // https://typescript-eslint.io/rules/explicit-module-boundary-types/
             '@typescript-eslint/explicit-module-boundary-types': 'off',
 
             // Disallow harmful bultin types
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/ban-types.md
+            // https://typescript-eslint.io/rules/ban-types/
             //! Commented because we use the recommended version of this rule
             // '@typescript-eslint/ban-types': 'off',
 
             // Disallow // @ts comments
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/ban-ts-comment.md
+            // https://typescript-eslint.io/rules/ban-ts-comment/
             '@typescript-eslint/ban-ts-comment': [
               'error',
               {
@@ -263,11 +263,11 @@ module.exports = !hasTypescript
             ],
 
             // Disallows unnecessary constraints on generic types
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-type-constraint.md
+            // https://typescript-eslint.io/rules/no-unnecessary-type-constraint/
             '@typescript-eslint/no-unnecessary-type-constraint': 'warn',
 
             // Enforces consistent usage of type imports
-            // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-imports.md
+            // https://typescript-eslint.io/rules/consistent-type-imports/
             '@typescript-eslint/consistent-type-imports': [
               'warn',
               {


### PR DESCRIPTION
## Summary

Fixes the link to the documentation of Typescript ESLint, as they now have a proper docs website.
