### PR TITLE
Remove deprecated eslint plugin package for @vtex/admin-ui

### DIFF
--- a/packages/eslint-config-vtex-react/CHANGELOG.md
+++ b/packages/eslint-config-vtex-react/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Deprecated eslint plugin and preset for VTEX Admin UI
 
 ## [9.0.0] - 2022-03-15
 ### Changed

--- a/packages/eslint-config-vtex-react/index.js
+++ b/packages/eslint-config-vtex-react/index.js
@@ -1,8 +1,6 @@
 module.exports = {
-  plugins: ['@vtex/admin-ui'],
   extends: [
     'eslint-config-vtex',
-    'plugin:@vtex/admin-ui/recommended',
     './rules/react.js',
     './rules/react-hooks.js',
     './rules/react-a11y.js',

--- a/packages/eslint-config-vtex-react/package.json
+++ b/packages/eslint-config-vtex-react/package.json
@@ -36,7 +36,6 @@
     "directory": "packages/eslint-config-vtex-react"
   },
   "dependencies": {
-    "@vtex/eslint-plugin-admin-ui": "^0.2.9",
     "eslint-config-vtex": "^15.0.2",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,11 +1787,6 @@
     "@typescript-eslint/types" "5.15.0"
     eslint-visitor-keys "^3.0.0"
 
-"@vtex/eslint-plugin-admin-ui@^0.2.9":
-  version "0.2.21"
-  resolved "https://registry.yarnpkg.com/@vtex/eslint-plugin-admin-ui/-/eslint-plugin-admin-ui-0.2.21.tgz#c78ad695ed3a14adfcee52ce786d4d975e6f0dd4"
-  integrity sha512-cv2ZoDEoQ8uGy3A07qqHXLEiCxslbZT0LMbFou0g12iQQqJE5MmfP0KktL8dvrZqK8I+umkuzRdw8SBWBOvDBg==
-
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz#2ab8ed81f5bb5452a85f25758eb9b8681982fd2e"


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR removes the `@vtex/eslint-plugin-admin-ui` package from `vtex-react`.

#### What problem is this solving?

This package was deprecated and removed in vtex/admin-ui#345 and is incompatible with ESLint 8. Since it won't be evolved anymore it doesn't make sense to continue to include it as part of `eslint-config-vtex-react`.

#### How should this be manually tested?

N/A

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
